### PR TITLE
fix(ishortcut): apply max download image limit per version and reload settings

### DIFF
--- a/scripts/civitai_manager_libs/ishortcut.py
+++ b/scripts/civitai_manager_libs/ishortcut.py
@@ -741,6 +741,12 @@ def _download_model_images(version_list: list, modelid: str, progress=None):
         modelid: Model ID for debug logging
         progress: Progress callback for UI updates
     """
+    # Ensure latest configuration values loaded before downloading
+    setting.load_data()
+    util.printD(
+        f"[ishortcut._download_model_images] Current shortcut_max_download_image_per_version: "
+        f"{setting.shortcut_max_download_image_per_version}"
+    )
     if not version_list:
         util.printD(f"[ishortcut._download_model_images] No images to download for {modelid}")
         return
@@ -779,6 +785,11 @@ def _collect_images_to_download(version_list: list, modelid: str) -> list:
         list: List of (version_id, url, filepath) tuples to download
     """
     util.printD(f"[ishortcut._collect_images_to_download] Collecting images for {modelid}")
+    util.printD(
+        "[ishortcut._collect_images_to_download] "
+        f"shortcut_max_download_image_per_version = "
+        f"{setting.shortcut_max_download_image_per_version}"
+    )
     all_images_to_download = []
 
     for version_idx, image_list in enumerate(version_list):
@@ -809,7 +820,6 @@ def _collect_images_to_download(version_list: list, modelid: str) -> list:
             setting.shortcut_max_download_image_per_version
             and len(images_for_version) > setting.shortcut_max_download_image_per_version
         ):
-
             original_count = len(images_for_version)
             images_for_version = images_for_version[
                 : setting.shortcut_max_download_image_per_version
@@ -817,6 +827,12 @@ def _collect_images_to_download(version_list: list, modelid: str) -> list:
             util.printD(
                 f"[ishortcut._collect_images_to_download] Limited images from "
                 f"{original_count} to {len(images_for_version)} per version limit"
+            )
+        else:
+            util.printD(
+                f"[ishortcut._collect_images_to_download] No limit applied: "
+                f"setting={setting.shortcut_max_download_image_per_version}, "
+                f"count={len(images_for_version)}"
             )
 
         all_images_to_download.extend(images_for_version)

--- a/tests/test_image_download_limit.py
+++ b/tests/test_image_download_limit.py
@@ -1,0 +1,60 @@
+import os
+
+import pytest
+
+import civitai_manager_libs.ishortcut as ishortcut
+import civitai_manager_libs.setting as setting
+
+
+@pytest.fixture(autouse=True)
+def patch_exists_and_get(monkeypatch):
+    """Patch os.path.exists and setting.get_image_url_to_shortcut_file for testing."""
+
+    def fake_exists(path):
+        return False
+
+    monkeypatch.setattr(os.path, "exists", fake_exists)
+
+    def fake_get_image_url_to_shortcut_file(modelid, vid, url):
+        return f"/tmp/{modelid}_{vid}.jpg"
+
+    monkeypatch.setattr(
+        setting,
+        "get_image_url_to_shortcut_file",
+        fake_get_image_url_to_shortcut_file,
+    )
+
+
+def test_collect_images_no_limit():
+    """When shortcut_max_download_image_per_version is 0, all images should be collected."""
+    version_list = [
+        [(1, "url1"), (2, "url2"), (3, "url3")],
+        [(4, "url4"), (5, "url5")],
+    ]
+    setting.shortcut_max_download_image_per_version = 0
+    result = ishortcut._collect_images_to_download(version_list, modelid="123")
+    assert len(result) == 5
+    expected = [
+        (1, "url1", "/tmp/123_1.jpg"),
+        (2, "url2", "/tmp/123_2.jpg"),
+        (3, "url3", "/tmp/123_3.jpg"),
+        (4, "url4", "/tmp/123_4.jpg"),
+        (5, "url5", "/tmp/123_5.jpg"),
+    ]
+    assert result == expected
+
+
+def test_collect_images_with_limit():
+    """
+    When shortcut_max_download_image_per_version > 0,
+    only up to the limit are collected per version.
+    """
+    version_list = [[(1, "url1"), (2, "url2"), (3, "url3")]]
+    setting.shortcut_max_download_image_per_version = 2
+    result = ishortcut._collect_images_to_download(version_list, modelid="abc")
+    assert len(result) == 2
+    expected = [
+        (1, "url1", "/tmp/abc_1.jpg"),
+        (2, "url2", "/tmp/abc_2.jpg"),
+    ]
+    assert result == expected


### PR DESCRIPTION
# [Bug Fix] Apply max download image limit per version and reload settings 工作報告

**任務**: 修正「Maximum number of download images per version」設定值未正確套用至模型註冊流程，並在下載前重新載入設定值  
**類型**: Bug Fix  
**狀態**: 已完成

## 一、任務概述
在 Manage → Setting 設定「Maximum number of download images per version」後，模型註冊流程仍下載所有可用圖片，未依設定值限制下載數量。本次修正需於實際下載流程開始前重新載入使用者設定，並於圖片收集階段正確套用限制邏輯。

## 二、實作內容

### 2.1 在 _download_model_images 中重新載入設定值並加入除錯日誌
- 呼叫 setting.load_data() 以確保載入最新的 shortcut_max_download_image_per_version 設定值
- 新增 debug 輸出顯示當前設定值
- 【F:scripts/civitai_manager_libs/ishortcut.py†L744-L749】

### 2.2 在 _collect_images_to_download 中加入更多 debug 日誌並強化限制邏輯
- 列印設定值與每版圖片數量的 debug 資訊
- 當未達到限制時也列印相關訊息，並在超出限制時正確裁剪列表
- 【F:scripts/civitai_manager_libs/ishortcut.py†L787-L795】【F:scripts/civitai_manager_libs/ishortcut.py†L816-L834】

### 2.3 新增單元測試驗證限制邏輯
- 測試設定為 0 時不做限制，收集所有圖片
- 測試設定大於 0 時，每版本僅收集設定數量的圖片
- 【F:tests/test_image_download_limit.py†L1-L46】

## 三、技術細節

### 3.1 架構變更
本次僅在現有函式中加入設定重新載入與 debug 日誌，無額外架構層面調整。

## 四、測試與驗證

### 4.1 程式碼品質檢查
scripts/civitai_manager_libs/ishortcut.py:4:1: F401 'gradio as gr' imported but unused
scripts/civitai_manager_libs/ishortcut.py:10:5: E731 do not assign a lambda expression, use a def
scripts/civitai_manager_libs/ishortcut.py:127:5: F841 local variable 'e' is assigned to but never used
scripts/civitai_manager_libs/ishortcut.py:180:101: E501 line too long (118 > 100 characters)
scripts/civitai_manager_libs/ishortcut.py:309:13: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:328:5: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:377:9: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:387:9: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:398:9: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:853:101: E501 line too long (116 > 100 characters)
scripts/civitai_manager_libs/ishortcut.py:902:101: E501 line too long (102 > 100 characters)
scripts/civitai_manager_libs/ishortcut.py:993:13: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:1054:13: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:1126:5: F824 `global thumbnail_max_size` is unused: name is never assigned in scope
scripts/civitai_manager_libs/ishortcut.py:1139:5: F841 local variable 'e' is assigned to but never used
scripts/civitai_manager_libs/ishortcut.py:1153:9: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:1205:9: F841 local variable 'filenames' is assigned to but never used
scripts/civitai_manager_libs/ishortcut.py:1249:9: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:1315:5: E722 do not use bare 'except'
scripts/civitai_manager_libs/ishortcut.py:1323:5: F841 local variable 'e' is assigned to but never used
scripts/civitai_manager_libs/ishortcut.py:1337:5: F841 local variable 'e' is assigned to but never used
scripts/civitai_manager_libs/ishortcut.py:1359:5: E722 do not use bare 'except'

### 4.2 單元測試
........................................................................ [ 16%]
........................................................................ [ 33%]
........................................................................ [ 50%]
........................................................................ [ 66%]
...................................sssssssss............................ [ 83%]
......................................................................   [100%]
421 passed, 9 skipped, 5 warnings in 9.07s
All tests passed.

## 八、檔案異動清單
| 檔案路徑 | 異動類型 | 描述 |
|---------|----------|------|
| scripts/civitai_manager_libs/ishortcut.py | 修改 | 重新載入設定並加入 debug 日誌，強化 per-version 圖片下載限制邏輯 |
| tests/test_image_download_limit.py | 新增 | 單元測試：驗證 per-version 圖片下載限制邏輯 |

## 九、關聯項目
Resolves #18